### PR TITLE
Changed / Update WordPress to 4.4 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "WordPress"]
 	path = WordPress
+    branch = 4.4-branch
 	url = git://github.com/WordPress/WordPress.git
-    branch = 4.1-branch


### PR DESCRIPTION
Split the WordPress core update out of the plugins update. Necessary because running `git submodule update --remote` on the production server is a pain.