### PR TITLE
Bug / Facebook Like Count Gone

### DIFF
--- a/content/themes/easier-english-bg-theme/content-superFormat.php
+++ b/content/themes/easier-english-bg-theme/content-superFormat.php
@@ -87,7 +87,16 @@
                     </p>
                     <p>
                         Харесай урока:
-                        <div class="fb-like" data-href="<?= get_permalink( $id ) ?>" data-layout="button_count" data-action="like" data-show-faces="false" data-share="false"></div>
+                        <?php
+                            /**
+                             * Migrating urls to https breaks the fb like count :(
+                             * That's why reference the data-href fb button link to http.
+                             * Sadly, this is the only way to keep the like count.
+                             *
+                             * http://stackoverflow.com/questions/12229801/facebook-like-on-https
+                             */
+                        ?>
+                        <div class="fb-like" data-href="<?= 'http://easierenglish.bg' . $_SERVER['REQUEST_URI'] ?>" data-layout="button_count" data-action="like" data-show-faces="false" data-share="false"></div>
                     </p>
 
                     <p>


### PR DESCRIPTION
Fixed: After moving all urls to https, facebook like count was gone :( To keep the old likes, feed http link to the facebook like button.