### PR TITLE
Config / Facebook Like Count

### DIFF
--- a/content/plugins/seo-ultimate/modules/opengraph/opengraph.php
+++ b/content/plugins/seo-ultimate/modules/opengraph/opengraph.php
@@ -122,7 +122,11 @@ class SU_OpenGraph extends SU_Module {
 						$tags['og:description'] = $meta_desc;
 				
 				//URL
-				$tags['og:url'] = get_permalink($post->ID);
+				/**
+				 * Fixed: Force http to og:url,
+				 * otherwise, after moving to https, fb likes count is gone
+				 */
+				$tags['og:url'] = 'http://easierenglish.bg' . $_SERVER['REQUEST_URI'];
 				
 				//Image
 				$tags['og:image'] = $this->jlsuggest_value_to_url($this->get_postmeta('og_image'), true);


### PR DESCRIPTION
Force http in `og:url` to save the old likes, that happened before moving to https.

Attention, I edited SEO Ultimate plugin code, so in case we need to update it - beware!